### PR TITLE
Update Seeder untuk menyertakan path ke file Food Drink

### DIFF
--- a/database/seeders/FilmSeeder.php
+++ b/database/seeders/FilmSeeder.php
@@ -26,7 +26,7 @@ class FilmSeeder extends Seeder
                 'duration_mins' => 160,
                 'sinopsis' => 'Placeholder_Sinopsis_Biography',
                 'rating' => 8.2,
-                'poster_path' => 'poster/fake_film1.png',
+                'poster_path' => 'poster/Mr_Thinker.jpg',
                 'user_id' => 2,
                 'created_at' => now(),
                 'updated_at' => now()
@@ -39,7 +39,7 @@ class FilmSeeder extends Seeder
                 'duration_mins' => 120,
                 'sinopsis' => 'Placeholder_Sinopsis_Drama',
                 'rating' => 8.5,
-                'poster_path' => 'poster/fake_film2.png',
+                'poster_path' => 'poster/Jalan_Malam_Kenangan.jpg',
                 'user_id' => 2,
                 'created_at' => now(),
                 'updated_at' => now()
@@ -52,7 +52,7 @@ class FilmSeeder extends Seeder
                 'duration_mins' => 110,
                 'sinopsis' => 'Placeholder_Sinopsis_Adventure',
                 'rating' => 7.0,
-                'poster_path' => 'poster/fake_film3.png',
+                'poster_path' => 'poster/The_Third_One.jpg',
                 'user_id' => 2,
                 'created_at' => now(),
                 'updated_at' => now()

--- a/database/seeders/FoodDrinkSeeder.php
+++ b/database/seeders/FoodDrinkSeeder.php
@@ -19,7 +19,7 @@ class FoodDrinkSeeder extends Seeder
                 'name' => 'Salt Popcorn',
                 'type' => 'food',
                 'price' => 35000.00,
-                'image_path' => null,
+                'image_path' => 'FoodDrink/popcorn.jpg',
                 'created_at' => now(),
                 'updated_at' => now()
             ],
@@ -27,7 +27,7 @@ class FoodDrinkSeeder extends Seeder
                 'name' => 'Caramel Popcorn',
                 'type' => 'food',
                 'price' => 45000.00,
-                'image_path' => null,
+                'image_path' => 'FoodDrink/popcorn.jpg',
                 'created_at' => now(),
                 'updated_at' => now()
             ],
@@ -35,7 +35,7 @@ class FoodDrinkSeeder extends Seeder
                 'name' => 'Coffe Latte',
                 'type' => 'drink',
                 'price' => 25000.00,
-                'image_path' => null,
+                'image_path' => 'FoodDrink/latte.jpg',
                 'created_at' => now(),
                 'updated_at' => now()
             ],
@@ -43,7 +43,7 @@ class FoodDrinkSeeder extends Seeder
                 'name' => 'Matcha Latte',
                 'type' => 'drink',
                 'price' => 25000.00,
-                'image_path' => null,
+                'image_path' => 'FoodDrink/matcha.jpg',
                 'created_at' => now(),
                 'updated_at' => now()
             ]


### PR DESCRIPTION
Seeder diperbarui agar dapat menampilkan gambar valid
Untuk 'image_path' di food_drinks dan 'poster_path' di films
**Catatan (Tahap ini wajib dilakukan bagi yang demo besok):**
Agar gambar tidak error missing file atau tidak muncul maka pencet link di bawah
<a href=https://drive.google.com/drive/folders/1RyHxmVgmkuFqpJSpmLI_YX1n-yLJAjSO>Link Drive Proyek</a>
Download folder poster dan FoodDrink, lalu copy dua folder tersebut ke storage/app/public di proyek